### PR TITLE
[project]: Add the Ontology Engineering open-source project Semantica

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,10 @@ Reusable projects grouped by their primary engineering target:
 - [Mastra](https://github.com/mastra-ai/mastra)
 - [GPTSwarm](https://github.com/metauto-ai/GPTSwarm)
 
+### Ontology Engineering
+
+- [semantica](https://github.com/semantica-agi/semantica)
+
 ## 🚀 Applications
 
 Representative systems and application domains covered by the survey:

--- a/README.md
+++ b/README.md
@@ -603,6 +603,8 @@ Reusable projects grouped by their primary engineering target:
 
 ### System Intelligence
 
+#### Graph Engineering
+
 - [LangGraph](https://github.com/langchain-ai/langgraph)
 - [Microsoft Agent Framework](https://github.com/microsoft/agent-framework)
 - [Google ADK](https://github.com/google/adk-python)
@@ -613,9 +615,9 @@ Reusable projects grouped by their primary engineering target:
 - [Mastra](https://github.com/mastra-ai/mastra)
 - [GPTSwarm](https://github.com/metauto-ai/GPTSwarm)
 
-### Ontology Engineering
+#### Ontology Engineering
 
-- [semantica](https://github.com/semantica-agi/semantica)
+- [Semantica](https://github.com/semantica-agi/semantica)
 
 ## 🚀 Applications
 


### PR DESCRIPTION
https://github.com/semantica-agi/semantica
This open-source project is closely related to the ontology engineering discussed in your review paper, but it is not mentioned in the paper.

Fix the Issue #1 